### PR TITLE
Whiltelist a resource group that doesn't want to be auto-removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const persistResourceIdPrefixes = [
   "/subscriptions/937bc588-a144-4083-8612-5f9ffbbddb14/resourcegroups/intasldevrgeusa",
   "/subscriptions/937bc588-a144-4083-8612-5f9ffbbddb14/resourcegroups/mc_intasldevrgeusa_intasldevaksrpeusb_eastus",
   "/subscriptions/937bc588-a144-4083-8612-5f9ffbbddb14/resourcegroups/cupertino-test",
-  "/subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourcegroups/zhwen-domain"
+  "/subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourcegroups/zhwen-domain",
+  "/subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/azure-rest-api-cov"
 ];
 
 async function doCleanup(subsId, subsName, ttl, client, secret, tenant, envName) {


### PR DESCRIPTION
Whiltelist a resource group that doesn't want to be auto-removed, which is used for the Terraform coverage service.